### PR TITLE
Use VITE_API_URL env var in codegen.yml

### DIFF
--- a/codegen.yml
+++ b/codegen.yml
@@ -1,4 +1,4 @@
-schema: "http://localhost:4000/graphql"
+schema: ${VITE_API_URL:"http://localhost:4000/graphql"}
 documents: ["src/**/*.tsx", "!src/gql/*.tsx"]
 emitLegacyCommonJSImports: false
 ignoreNoDocuments: true


### PR DESCRIPTION
Use `VITE_API_URL` environment variable in `codegen.yml`. This allows Staging/Production deployments to connect to the API server.